### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ first step is to create an account at: [https://codeclimate.com](https://codecli
 
       For example, if your coverage data resides in a "lcov.info" file:
 
-          CODECLIMATE_REPO_TOKEN=ABCD11110000000 cat lcov.info | codeclimate
+          cat lcov.info | CODECLIMATE_REPO_TOKEN=ABCD11110000000 codeclimate
 
 The `CODECLIMATE_REPO_TOKEN` value is provided after you add your repo to your
 Code Climate account by clicking on "Setup Test Coverage" on the right hand side of your feed.


### PR DESCRIPTION
The example wasn't working for me, either on bash or zsh on Mac OS X, the env var should be before the `codeclimate` command. I think it should be updated on the site as well, since the idea is copy the command with the key already.
Also find a typo... (Istanbul was written instanbul)
