### PR TITLE
Added support for CI AppVeyor

### DIFF
--- a/ci_info.js
+++ b/ci_info.js
@@ -44,6 +44,14 @@ module.exports = {
         branch:           env.CI_BRANCH,
         commit_sha:       env.CI_COMMIT_ID,
       }
+    } else if (env.APPVEYOR) {
+      return {
+        name:             "appveyor",
+        build_identifier: env.APPVEYOR_BUILD_NUMBER,
+        branch:           env.APPVEYOR_REPO_BRANCH,
+        commit_sha:       env.APPVEYOR_REPO_COMMIT,
+        pull_request:     env.APPVEYOR_PULL_REQUEST_NUMBER,
+      }
     } else {
       return {};
     }

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var assert = require("assert");
 var fs = require('fs')
 var Formatter = require('../formatter.js');
+var CiInfo = require('../ci_info');
 
 describe('JSON', function(){
 
@@ -19,4 +20,33 @@ describe('JSON', function(){
       });
     });
   });
-})
+});
+
+describe('ci_info', function() {
+  describe('#getInfo', function() {
+    var bupenv = Object.keys(process.env);
+
+    afterEach(function(){
+      for(var pk in process.env) {
+        if (bupenv.indexOf(pk) < 0) {
+          delete process.env[pk];
+        }
+      }
+    });
+
+    it('should return travis-ci as name if process.env.TRAVIS is set', function() {
+      process.env.TRAVIS = 'true';
+
+      var ci = CiInfo.getInfo();
+      assert.equal(ci.name, 'travis-ci');
+    });
+
+    it('should return appveyor as name if process.env.APPVEYOR is set', function() {
+      process.env.APPVEYOR = 'true';
+
+      var ci = CiInfo.getInfo();
+      assert.equal(ci.name, 'appveyor');
+    });
+
+  });
+});


### PR DESCRIPTION
I have a node.js project that needs to be built and tested on a Windows machine. In [AppVeyor](http://www.appveyor.com) CI this is possible. But there is an issue with getting codeclimate to accept the coverage report when sending it from AppVeyor. There are detached HEADs and other stuff. So I thought it might help if codeclimate gets the proper CI info, i.e. branch and commit_sha.

Added a test as well.