### PR TITLE
Add Windows support

### DIFF
--- a/formatter.js
+++ b/formatter.js
@@ -23,7 +23,7 @@ Formatter.prototype.format = function(lcovData, callback) {
       run_at: Date.now(),
       partial: false,
       environment: {
-        pwd: process.cwd(),
+        pwd: process.cwd().split(path.sep).join('/'),
         package_version: pjson.version
       },
       ci_service: ci.getInfo()
@@ -63,6 +63,9 @@ Formatter.prototype.sourceFiles = function(data) {
     });
 
     var fileName = path.relative(self.rootDirectory(), elem.file);
+    if (path.sep !== '/') {
+      fileName = fileName.split(path.sep).join('/');
+    }
 
     source_files.push({
       name: fileName,

--- a/git_info.js
+++ b/git_info.js
@@ -4,13 +4,13 @@ var childProcess = require('child_process');
 module.exports = {
 
   head: function(cb) {
-    childProcess.exec("git log -1 --pretty=format:'%H'", function (error, stdout, stderr) {
+    childProcess.exec("git log -1 --pretty=format:%H", function (error, stdout, stderr) {
       return cb(error, stdout);
     });
   },
 
   committedAt: function(cb) {
-    childProcess.exec("git log -1 --pretty=format:'%ct'", function (error, stdout, stderr) {
+    childProcess.exec("git log -1 --pretty=format:%ct", function (error, stdout, stderr) {
       var result = null;
       var timestamp = null;
       if (stdout) {


### PR DESCRIPTION
As discussed in an email with Jonathan, codeclimate-test-report fails on Windows, since the payloads are broken. The server does not report this, however, which is further confusing.

The problems involve single-quotes not being a valid quoting mechanism on Windows (and since they aren't needed in this case, they were removed), and paths on Windows being delimited by `\` instead of `/`, which broke in CodeClimate back-end.

This set of changes should add Windows support to javascript-test-reported, which I guess is probably what was actually intended (to have Windows support), but the lack of error response from CodeClimate's back-end made this go under the radar.

Hope this helps! :+1: 