### PR TITLE
[#11][bugfix] Added handlers for cwd to be replaced with "." when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "node": ">=0.8.6"
   },
   "dependencies": {
+    "async": "~0.7.0",
     "lcov-parse": "0.0.6",
-    "request": "~2.34.0",
-    "async": "~0.7.0"
+    "request": "~2.34.0"
   },
   "repository": {
     "type": "git",

--- a/test/fixtures/lcov.info
+++ b/test/fixtures/lcov.info
@@ -1,5 +1,5 @@
 TN:
-SF:/Users/noah/p/request/lib/cookies.js
+SF:./lib/cookies.js
 FN:7,(anonymous_1)
 FN:17,RequestJar
 FN:20,(anonymous_3)
@@ -55,7 +55,7 @@ BRF:16
 BRH:5
 end_of_record
 TN:
-SF:/Users/noah/p/request/lib/copy.js
+SF:./lib/copy.js
 FN:2,copy
 FN:4,(anonymous_2)
 FNF:2

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ var Formatter = require('../formatter.js');
 describe('JSON', function(){
 
   var lcovFixture = fs.readFileSync('test/fixtures/lcov.info').toString();
-  var formatter = new Formatter({rootDirectory: "/Users/noah/p/request"});
+  var formatter = new Formatter({rootDirectory: "./node_modules/request"});
 
   describe('parse', function() {
     it("should return the correct filenames", function(done) {


### PR DESCRIPTION
Tested both with Mocha and on a local repo of my own.

* `formatter.js`
  * added regex to replace cwd with "." in lcov.info
  * added handler in Formatter.sourceFiles to take that change into account
    (test was failing)
* `package.json`
  * nothing really. npm install reordered the deps.
* `test/fixtures/lcov.info`
  * changed paths to be relative. There should probably be two lcov.info
    files, to account for relative and absolute pathing.
* `test/test.js`
  * changed rootDirectory being passed in to therequest folder from
    root of project. It originally was a hardcoded path and was failing
    on my system. Hopefully this will be more cross-system friendly.