### PR TITLE
Skip missing files in LCOV

### DIFF
--- a/formatter.js
+++ b/formatter.js
@@ -51,7 +51,17 @@ Formatter.prototype.sourceFiles = function(data) {
   var source_files = [];
   var self = this;
   data.forEach(function(elem, index) {
-    var content = fs.readFileSync(elem.file).toString();
+    var content;
+    try {
+      content = fs.readFileSync(elem.file).toString();
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        console.log('The file ' + elem.file + ' does not exist and will be skipped.');
+        content = '';
+      } else {
+        throw e;
+      }
+    }
     var numLines = content.split("\n").size
 
     var coverage = new Array(numLines);


### PR DESCRIPTION
If the formatter encounters an entry in the lcov report that does not exist in the file system it is skipped with a warning instead of dying with an exception.

In an ember-cli app the build step results in some files which do not exist in the source.  These files end up with lcov entries, but should not result in breaking coverage reporting.