### PR TITLE
Set minimum version of request to 2.40.0 (uses qs >1.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "lcov-parse": "0.0.6",
-    "request": "~2.34.0",
+    "request": "~2.40.0",
     "async": "~0.7.0"
   },
   "repository": {


### PR DESCRIPTION
Resolves https://app.snyk.io/vuln/npm:qs:20140806 and https://app.snyk.io/vuln/npm:qs:20140806-1