### PR TITLE
Fix reporting coverage for lcov files

### DIFF
--- a/formatter.js
+++ b/formatter.js
@@ -16,7 +16,7 @@ Formatter.prototype.rootDirectory = function() {
 };
 
 Formatter.prototype.parse = function(data, callback) {
-    if (/^TN:/.test(data)) {
+    if (/^SF:/m.test(data)) {
         lcovParse(data, callback);
     } else if (/^mode:/.test(data)) {
         gocoverParse(data, callback);
@@ -29,6 +29,10 @@ Formatter.prototype.format = function(coverageData, callback) {
   var self = this;
 
   self.parse(coverageData, function(parseError, data) {
+    if (parseError) {
+      throw parseError;
+    }
+
     var result = {
       source_files: self.sourceFiles(data),
       run_at: Date.now(),


### PR DESCRIPTION
`TN` is not always present in lcov files, but `SF` is as it is used to
specify the file path. Additionally, I added an error to handle the case
of an invalid format (which was being passed in this case).

@codeclimate/review 

Fixes #33 