### PR TITLE
Use git hash-object for blob id if available

### DIFF
--- a/formatter.js
+++ b/formatter.js
@@ -94,7 +94,7 @@ Formatter.prototype.sourceFiles = function(data) {
 
     source_files.push({
       name: fileName,
-      blob_id: git.calculateBlobId(content),
+      blob_id: git.blobId(elem.file, content),
       coverage: JSON.stringify(coverage)
     });
   });


### PR DESCRIPTION
This commit updates file blob_id generation by first shelling out to `git
hash-object`. If `git` or the file is unavailable, we'll fallback to our `sha1`
computation.

@codeclimate/review :mag_right: