### PR TITLE
Fixes upload to internal https

### DIFF
--- a/http_client.js
+++ b/http_client.js
@@ -11,6 +11,7 @@ var options = {
     "User-Agent": "Code Climate (JavaScript Test Reporter v" + pjson.version + ")",
     "Content-Type": "application/json"
   },
+  rejectUnauthorized: false,
   timeout: 5000
 };
 


### PR DESCRIPTION
When using the enterprise version of CC I found that maybe
the https configuration does not work so well (?) or the certificate
can't be validated against the list of supplied CAs.

Adding `rejectUnauthorized: false` seems to allow uploading
the coverage files to CC.

More info on the option: https://nodejs.org/api/tls.html

Would this be an acceptable solution? Or is this something we'd
have to fix in our end?