### PR TITLE
Skip certificate option

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "env": {
-    "node": true
+    "node": true,
+    "mocha": true
   },
   "rules": {
     "brace-style": [2, "1tbs", { "allowSingleLine": true }],

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 node_modules
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ Code Climate account by clicking on "Setup Test Coverage" on the right hand side
 
 Please contact hello@codeclimate.com if you need any assistance setting this up.
 
+## Usage
+
+```
+Usage: codeclimate [options] < <file>
+
+Options:
+
+  -h, --help       output usage information
+  -V, --version    output the version number
+  -S, --skip-cert  skips verification of the chain of certificate
+```
+
 ## Troubleshooting
 
 If you're having trouble setting up or working with our test coverage feature, [see our detailed help doc](http://docs.codeclimate.com/article/220-help-im-having-trouble-with-test-coverage), which covers the most common issues encountered.

--- a/bin/codeclimate.js
+++ b/bin/codeclimate.js
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
 
+var commander = require("commander");
+var pkg = require("../package.json");
 var Formatter = require("../formatter");
-var client         = require('../http_client');
+var client = require('../http_client');
+
+commander
+  .version(pkg.version)
+  .usage('[options] < <file>')
+  .option("-S, --skip-cert", "skips verification of the chain of certificate")
+  .parse(process.argv);
 
 process.stdin.resume();
 process.stdin.setEncoding("utf8");
@@ -9,7 +17,7 @@ process.stdin.setEncoding("utf8");
 var input = "";
 
 process.stdin.on("data", function(chunk) {
-    input += chunk;
+  input += chunk;
 });
 
 var repo_token = process.env.CODECLIMATE_REPO_TOKEN;
@@ -30,7 +38,9 @@ process.stdin.on("end", function() {
         console.log(json);
       } else {
         json['repo_token'] = repo_token;
-        client.postJson(json);
+        client.postJson(json, {
+          skip_certificate: commander.skipCert
+        });
       }
     }
   });

--- a/http_client.js
+++ b/http_client.js
@@ -20,7 +20,10 @@ if (proxy) {
   options.proxy = proxy;
 }
 
-var postJson = function(data) {
+var postJson = function(data, opts) {
+  opts = opts || {};
+
+  options.rejectUnauthorized = !opts.skip_certificate;
 
   var parts = url.parse(options.url);
 
@@ -28,6 +31,17 @@ var postJson = function(data) {
   console.log("Sending test coverage results to " + parts.host + " ...");
   request(options, function(error, response, body) {
     if (error) {
+      if (error.code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+        console.error(
+          '\n' +
+          'It looks like you might be trying to send coverage to an\n' +
+          'enterprise version of CodeClimate with a (probably) invalid or\n' +
+          'incorrectly configured certificate chain. If you are sure about\n' +
+          'where you are sending your data, add the -S/--skip-cert flag and\n' +
+          'try again. Run with --help for more info.\n'
+        );
+      }
+
       console.error("A problem occurred", error);
     }
     if (response) {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
+    "async": "~1.5.2",
+    "commander": "2.9.0",
     "lcov-parse": "0.0.10",
-    "request": "~2.72.0",
-    "async": "~1.5.2"
+    "request": "~2.72.0"
   },
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var fs = require('fs')
+var fs = require('fs');
 var Formatter = require('../formatter.js');
 var CiInfo = require('../ci_info');
 
@@ -16,7 +16,7 @@ describe('JSON', function(){
         var names = data.source_files.map(function(elem) {
           return elem.name;
         });
-        expected = ["lib/cookies.js", "lib/copy.js"]
+        var expected = ["lib/cookies.js", "lib/copy.js"];
         assert.deepEqual(expected, names);
         done();
       });


### PR DESCRIPTION
`—skip-cert/-S` adds the possibily to skip the verification
of the certificate chain. It could be done without commander,
but commander adds a nice summary of what’s possible.

I've also taken the liberty to fix a couple of linting issues!

I have not added tests since it seems like the bits I've touched
you are not testing and collecting coverage from.

Sorry for taing so long, I couldn't find the time to work on it.