### PR TITLE
Upgrade request to 2.74 to address deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "async": "~1.5.2",
     "commander": "2.9.0",
     "lcov-parse": "0.0.10",
-    "request": "~2.72.0"
+    "request": "~2.74.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
tough-cookie <=2.2.2 was flagged for a [security vulnerability](https://nodesecurity.io/advisories/130), and the smallest upgrade to request to get the fixed tough-cookie version is request@2.74. This patch upgrades to that version.