### PR TITLE
Update engines depedency to node >= 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mocha": "^2.5.3"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">= 4"
   },
   "dependencies": {
     "async": "~1.5.2",


### PR DESCRIPTION
The requests package dropped support for node < 4 in [v2.75.0](https://github.com/request/request/blob/master/CHANGELOG.md#v2750-20160917).

Since we rely on the requests package within this test reporter, our own engines dependency should match.